### PR TITLE
 update sbarchopt for segomoe updates 

### DIFF
--- a/requirements-tests.txt
+++ b/requirements-tests.txt
@@ -1,3 +1,5 @@
 pytest
 testbook~=0.4.2
 matplotlib
+smt
+numba~=0.57

--- a/sb_arch_opt/algo/arch_sbo/api.py
+++ b/sb_arch_opt/algo/arch_sbo/api.py
@@ -30,7 +30,8 @@ from sb_arch_opt.algo.arch_sbo.metrics import *
 from sb_arch_opt.algo.arch_sbo.hc_strategy import *
 
 if not HAS_ARCH_SBO:
-    get_sbo_termination = lambda *_, **__: None
+    def get_sbo_termination(*_, **__):
+        return None
 
 
 __all__ = ['get_arch_sbo_rbf', 'get_arch_sbo_gp', 'HAS_ARCH_SBO', 'get_sbo_termination', 'get_sbo',

--- a/sb_arch_opt/algo/arch_sbo/models.py
+++ b/sb_arch_opt/algo/arch_sbo/models.py
@@ -65,7 +65,7 @@ __all__ = ['check_dependencies', 'HAS_ARCH_SBO', 'ModelFactory', 'MixedDiscreteN
 
 def check_dependencies():
     if not HAS_ARCH_SBO:
-        raise ImportError(f'ArchSBO dependencies not installed: pip install sb-arch-opt[arch_sbo]')
+        raise ImportError('ArchSBO dependencies not installed: pip install sb-arch-opt[arch_sbo]')
 
 
 @dataclass

--- a/sb_arch_opt/algo/botorch_interface/algo.py
+++ b/sb_arch_opt/algo/botorch_interface/algo.py
@@ -43,7 +43,7 @@ __all__ = ['AxInterface', 'check_dependencies']
 
 def check_dependencies():
     if not HAS_BOTORCH:
-        raise ImportError(f'BoTorch/Ax dependencies not installed: python setup.py install[botorch]')
+        raise ImportError('BoTorch/Ax dependencies not installed: python setup.py install[botorch]')
 
 
 class AxInterface:

--- a/sb_arch_opt/algo/egor_interface/algo.py
+++ b/sb_arch_opt/algo/egor_interface/algo.py
@@ -52,7 +52,7 @@ log = logging.getLogger("sb_arch_opt.egor")
 
 def check_dependencies():
     if not HAS_EGOBOX:
-        raise ImportError(f"egobox not installed!")
+        raise ImportError("egobox not installed!")
 
 
 class EgorArchOptInterface:
@@ -155,7 +155,7 @@ class EgorArchOptInterface:
         population = load_from_previous_results(self._problem, results_folder)
         if population is None:
             log.info(
-                f"No previous population found, not changing initialization strategy"
+                "No previous population found, not changing initialization strategy"
             )
         else:
             self._x, self._x_failed, self._y = self._get_xy(population)

--- a/sb_arch_opt/algo/hebo_interface/algo.py
+++ b/sb_arch_opt/algo/hebo_interface/algo.py
@@ -48,7 +48,7 @@ log = logging.getLogger('sb_arch_opt.hebo')
 
 def check_dependencies():
     if not HAS_HEBO:
-        raise ImportError(f'HEBO dependencies not installed: python setup.py install[hebo]')
+        raise ImportError('HEBO dependencies not installed: python setup.py install[hebo]')
 
 
 class HEBOArchOptInterface:

--- a/sb_arch_opt/algo/pymoo_interface/storage_restart.py
+++ b/sb_arch_opt/algo/pymoo_interface/storage_restart.py
@@ -94,7 +94,7 @@ def initialize_from_previous_results(algorithm: Algorithm, problem: ArchOptProbl
     # Try to load from previous results
     population = load_from_previous_results(problem, result_folder, **kwargs)
     if population is None:
-        log.info(f'No previous population found, not changing initialization strategy')
+        log.info('No previous population found, not changing initialization strategy')
         return False
 
     # Set static initialization on the algorithm to start from the loaded population

--- a/sb_arch_opt/algo/segomoe_interface/algo.py
+++ b/sb_arch_opt/algo/segomoe_interface/algo.py
@@ -31,12 +31,12 @@ from sb_arch_opt.util import capture_log
 from pymoo.core.population import Population
 from sb_arch_opt.problem import ArchOptProblemBase
 from pymoo.util.nds.non_dominated_sorting import NonDominatedSorting
+from sb_arch_opt.algo.arch_sbo.models import ModelFactory
 
 try:
     from segomoe.sego import Sego
     from segomoe.constraint import Constraint
     from segomoe.sego_defs import get_sego_file_map, ExitStatus
-    from sb_arch_opt.algo.arch_sbo.models import ModelFactory
 
     HAS_SEGOMOE = True
 except ImportError:

--- a/sb_arch_opt/algo/segomoe_interface/algo.py
+++ b/sb_arch_opt/algo/segomoe_interface/algo.py
@@ -32,7 +32,7 @@ from pymoo.core.population import Population
 from sb_arch_opt.problem import ArchOptProblemBase
 from pymoo.util.nds.non_dominated_sorting import NonDominatedSorting
 from sb_arch_opt.algo.arch_sbo.models import ModelFactory
-
+from smt.surrogate_models.krg_based import MixIntKernelType
 try:
     from segomoe.sego import Sego
     from segomoe.constraint import Constraint

--- a/sb_arch_opt/algo/segomoe_interface/algo.py
+++ b/sb_arch_opt/algo/segomoe_interface/algo.py
@@ -49,7 +49,7 @@ log = logging.getLogger('sb_arch_opt.segomoe')
 
 def check_dependencies():
     if not HAS_SEGOMOE:
-        raise ImportError(f'SEGOMOE not installed!')
+        raise ImportError('SEGOMOE not installed!')
 
 
 class SEGOMOEInterface:

--- a/sb_arch_opt/algo/segomoe_interface/algo.py
+++ b/sb_arch_opt/algo/segomoe_interface/algo.py
@@ -209,8 +209,35 @@ class SEGOMOEInterface:
 
     def _sample_doe(self, n: int) -> np.ndarray:
         return HierarchicalSampling().do(self._problem, n).get('X')
-
+    
     def run_infills(self, n_infills: int = None):
+        if n_infills is None:
+            n_infills = self.n_infill
+        i_eval = 0
+    
+        def _grouped_eval(x):
+             nonlocal i_eval
+             i_eval += 1
+             log.info(f"Evaluating: {i_eval}/{n_infills}")
+    
+             x, x_failed, y = self._get_xy(self._evaluate(np.array([x])))
+    
+             self._x = np.row_stack([self._x, x])
+             self._y = np.row_stack([self._y, y])
+             self._x_failed = np.row_stack([self._x_failed, x_failed])
+             self._save_results()
+    
+             if len(x_failed) > 0:
+                 return [], True
+             return y[0, :], False
+    
+        log.info(
+            f"Running SEGO for {n_infills} infills ({self._x.shape[0]} points in database)"
+        )
+        sego = self._get_sego(_grouped_eval)
+        sego.run_optim(n_iter=n_infills)   
+        
+    def run_infills_ask_tell(self, n_infills: int = None):
         if n_infills is None:
             n_infills = self.n_infill
 
@@ -251,21 +278,34 @@ class SEGOMOEInterface:
     def _get_sego(self, f_grouped):
         design_space_spec = self._get_design_space()
 
-        model_type = {
-            'type': 'MIXEDsmt' if design_space_spec.is_mixed_discrete else 'KRGsmt',
-            'regr': 'constant',
-            'corr': 'squar_exp',
-            'theta0': [1e-3],
-            'thetaL': [1e-6],
-            'thetaU': [10.],
-            'normalize': True,
-            **self.model_options,
-        }
         if design_space_spec.is_mixed_discrete:
-            raise RuntimeError('Mixed-discrete API currently not supported')
-            # model_type['xtypes'] = design_space_spec.var_types
-            # model_type['xlimits'] = design_space_spec.var_limits
-
+            model_type = {
+                "type": "MIXED",
+                "name": "KRG",
+                "regr": "constant",
+                "corr": "squar_exp",
+                "design_space": design_space_spec.design_space,
+                "categorical_kernel": MixIntKernelType.GOWER,
+                "theta0": [1e-3],
+                "thetaL": [1e-6],
+                "thetaU": [10.0],
+                "normalize": True,
+                **self.model_options,
+            }
+        else:
+            model_type = {
+                "name": "KRG",
+                "regr": "constant",
+                "corr": "squar_exp",
+                "design_space": design_space_spec.design_space,
+                "categorical_kernel": MixIntKernelType.GOWER,
+                "theta0": [1e-3],
+                "thetaL": [1e-6],
+                "thetaU": [10.0],
+                "normalize": True,
+                **self.model_options,
+            }
+       
         optim_settings = {
             'grouped_eval': True,
             'n_obj': self._problem.n_obj,

--- a/sb_arch_opt/algo/smarty_interface/algo.py
+++ b/sb_arch_opt/algo/smarty_interface/algo.py
@@ -44,7 +44,7 @@ log = logging.getLogger('sb_arch_opt.smarty')
 
 def check_dependencies():
     if not HAS_SMARTY:
-        raise ImportError(f'SMARTy not installed!')
+        raise ImportError('SMARTy not installed!')
 
 
 class SMARTyArchOptInterface:

--- a/sb_arch_opt/algo/tpe_interface/api.py
+++ b/sb_arch_opt/algo/tpe_interface/api.py
@@ -51,7 +51,7 @@ log = logging.getLogger('sb_arch_opt.tpe')
 
 def check_dependencies():
     if not HAS_TPE:
-        raise RuntimeError(f'TPE dependencies not installed: pip install -e .[tpe]')
+        raise RuntimeError('TPE dependencies not installed: pip install -e .[tpe]')
 
 
 class ArchTPEInterface:
@@ -69,9 +69,9 @@ class ArchTPEInterface:
         capture_log()
 
         if problem.n_obj != 1:
-            raise ValueError(f'Currently only single-objective problems are supported!')
+            raise ValueError('Currently only single-objective problems are supported!')
         if problem.n_ieq_constr != 0 or problem.n_eq_constr != 0:
-            raise ValueError(f'Currently only unconstrained problems are supported!')
+            raise ValueError('Currently only unconstrained problems are supported!')
 
         self._problem = problem
         self._optimizer: Optional['TPEOptimizer'] = None
@@ -194,7 +194,7 @@ class TPEAlgorithm(Algorithm):
 
     def _setup(self, problem, **kwargs):
         if not isinstance(problem, ArchOptProblemBase):
-            raise RuntimeError(f'The TPE algorithm only works with SBArchOpt problem definitions!')
+            raise RuntimeError('The TPE algorithm only works with SBArchOpt problem definitions!')
 
         self._interface = interface = ArchTPEInterface(problem)
         interface.initialize()

--- a/sb_arch_opt/algo/trieste_interface/algo.py
+++ b/sb_arch_opt/algo/trieste_interface/algo.py
@@ -75,7 +75,7 @@ FAILED = 'FAILED'
 
 def check_dependencies():
     if not HAS_TRIESTE:
-        raise ImportError(f'Trieste dependencies not installed: python setup.py install[trieste]')
+        raise ImportError('Trieste dependencies not installed: python setup.py install[trieste]')
 
 
 class ArchOptBayesianOptimizer(BayesianOptimizer):

--- a/sb_arch_opt/correction.py
+++ b/sb_arch_opt/correction.py
@@ -147,7 +147,7 @@ class EagerCorrectorBase(CorrectorBase):
     def _correct_x(self, x: np.ndarray, is_active: np.ndarray):
         x_valid, is_active_valid = self.x_valid_active
         if x_valid is None or is_active_valid is None:
-            raise CorrectorUnavailableError(f'Eager corrector unavailable because problem does not provide x_all')
+            raise CorrectorUnavailableError('Eager corrector unavailable because problem does not provide x_all')
 
         # Separate canonical design vectors
         correct_idx = self.get_canonical_idx(x) if self.correct_correct_x else self.get_correct_idx(x)

--- a/sb_arch_opt/design_space_explicit.py
+++ b/sb_arch_opt/design_space_explicit.py
@@ -201,7 +201,7 @@ class ExplicitArchDesignSpace(ArchDesignSpace):
 
     def _block_after_init(self):
         if self._is_initialized:
-            raise RuntimeError(f'Cannot change variables or constraints after usage!')
+            raise RuntimeError('Cannot change variables or constraints after usage!')
 
     def add_param(self, param: ParamType):
         self.add_params([param])

--- a/sb_arch_opt/problems/hierarchical.py
+++ b/sb_arch_opt/problems/hierarchical.py
@@ -20,7 +20,6 @@ import enum
 import numpy as np
 from typing import *
 from deprecated import deprecated
-from scipy.spatial import distance
 from sb_arch_opt.sampling import *
 from pymoo.problems.multi.zdt import ZDT1
 from sb_arch_opt.problems.discrete import *
@@ -1125,14 +1124,16 @@ class TunableHierarchicalMetaProblem(HierarchyProblemBase):
 class HierBranin(TunableHierarchicalMetaProblem):
 
     def __init__(self):
-        factory = lambda n: MDBranin()
+        def factory(n):
+            return MDBranin()
         super().__init__(factory, imp_ratio=5., n_subproblem=50, diversity_range=.5, n_opts=3)
 
 
 class TunableZDT1(TunableHierarchicalMetaProblem):
 
     def __init__(self, imp_ratio=1., n_subproblem=100, diversity_range=.5, n_opts=3, cont_ratio=1.):
-        factory = lambda n: NoHierarchyWrappedProblem(ZDT1(n_var=n))
+        def factory(n):
+            return NoHierarchyWrappedProblem(ZDT1(n_var=n))
         super().__init__(factory, imp_ratio=imp_ratio, n_subproblem=n_subproblem, diversity_range=diversity_range,
                          n_opts=n_opts, cont_ratio=cont_ratio)
 
@@ -1164,14 +1165,16 @@ class HierDiscreteZDT1(TunableZDT1):
 class HierCantileveredBeam(TunableHierarchicalMetaProblem):
 
     def __init__(self):
-        factory = lambda n: ArchCantileveredBeam()
+        def factory(n):
+            return ArchCantileveredBeam()
         super().__init__(factory, imp_ratio=6., n_subproblem=20, diversity_range=.5)
 
 
 class HierCarside(TunableHierarchicalMetaProblem):
 
     def __init__(self):
-        factory = lambda n: ArchCarside()
+        def factory(n):
+            return ArchCarside()
         super().__init__(factory, imp_ratio=7., n_subproblem=50, diversity_range=.5)
 
 

--- a/sb_arch_opt/problems/rocket_eval.py
+++ b/sb_arch_opt/problems/rocket_eval.py
@@ -27,7 +27,6 @@ from dataclasses import dataclass
 
 import scipy.optimize as opt
 from scipy.integrate import solve_ivp
-from scipy.interpolate import interp1d
 
 try:
     import ambiance

--- a/sb_arch_opt/sampling.py
+++ b/sb_arch_opt/sampling.py
@@ -38,7 +38,6 @@ from pymoo.operators.sampling.rnd import FloatRandomSampling
 from pymoo.core.duplicate import DefaultDuplicateElimination
 from pymoo.operators.sampling.lhs import sampling_lhs_unit
 
-from sb_arch_opt.design_space import ArchDesignSpace
 from sb_arch_opt.problem import ArchOptProblemBase, ArchOptRepair
 from sb_arch_opt.util import get_np_random_singleton
 

--- a/sb_arch_opt/tests/algo/test_arch_sbo.py
+++ b/sb_arch_opt/tests/algo/test_arch_sbo.py
@@ -33,7 +33,8 @@ try:
 except ImportError:
     pass
 
-check_dependency = lambda: pytest.mark.skipif(not HAS_ARCH_SBO, reason='ArchSBO dependencies not installed')
+def check_dependency():
+    return pytest.mark.skipif(not HAS_ARCH_SBO, reason='ArchSBO dependencies not installed')
 
 
 @check_dependency()

--- a/sb_arch_opt/tests/algo/test_botorch.py
+++ b/sb_arch_opt/tests/algo/test_botorch.py
@@ -8,7 +8,8 @@ try:
 except ImportError:
     pass
 
-check_dependency = lambda: pytest.mark.skipif(not HAS_BOTORCH, reason='BoTorch/Ax dependencies not installed')
+def check_dependency():
+    return pytest.mark.skipif(not HAS_BOTORCH, reason='BoTorch/Ax dependencies not installed')
 
 
 @check_dependency()

--- a/sb_arch_opt/tests/algo/test_egor.py
+++ b/sb_arch_opt/tests/algo/test_egor.py
@@ -6,9 +6,8 @@ from sb_arch_opt.problems.discrete import MDBranin
 from sb_arch_opt.problems.constrained import ArchCantileveredBeam, MDCantileveredBeam
 from sb_arch_opt.algo.egor_interface.algo import EgorArchOptInterface
 
-check_dependency = lambda: pytest.mark.skipif(
-    not HAS_EGOBOX, reason="Egor dependencies not installed"
-)
+def check_dependency():
+    return pytest.mark.skipif(not HAS_EGOBOX, reason="Egor dependencies not installed")
 
 
 @check_dependency()

--- a/sb_arch_opt/tests/algo/test_hebo.py
+++ b/sb_arch_opt/tests/algo/test_hebo.py
@@ -5,7 +5,8 @@ from sb_arch_opt.problems.md_mo import MOZDT1
 from sb_arch_opt.problems.constrained import ArchCantileveredBeam
 from sb_arch_opt.algo.hebo_interface.algo import HEBOArchOptInterface
 
-check_dependency = lambda: pytest.mark.skipif(not HAS_HEBO, reason='HEBO dependencies not installed')
+def check_dependency():
+    return pytest.mark.skipif(not HAS_HEBO, reason='HEBO dependencies not installed')
 
 
 @check_dependency()

--- a/sb_arch_opt/tests/algo/test_segomoe.py
+++ b/sb_arch_opt/tests/algo/test_segomoe.py
@@ -8,7 +8,8 @@ from sb_arch_opt.problems.md_mo import MOHimmelblau, MDMOHimmelblau
 from sb_arch_opt.problems.constrained import ArchCantileveredBeam, MDCantileveredBeam, ArchWeldedBeam, MDWeldedBeam
 from sb_arch_opt.problems.hidden_constraints import Mueller01, MOHierarchicalRosenbrockHC
 
-check_dependency = lambda: pytest.mark.skipif(not HAS_SEGOMOE, reason='SEGOMOE dependencies not installed')
+def check_dependency():
+    return pytest.mark.skipif(not HAS_SEGOMOE, reason='SEGOMOE dependencies not installed')
 
 
 @pytest.fixture

--- a/sb_arch_opt/tests/algo/test_smarty.py
+++ b/sb_arch_opt/tests/algo/test_smarty.py
@@ -5,7 +5,8 @@ from sb_arch_opt.problems.continuous import Branin
 from sb_arch_opt.problems.constrained import ArchCantileveredBeam
 from sb_arch_opt.algo.smarty_interface.algo import SMARTyArchOptInterface
 
-check_dependency = lambda: pytest.mark.skipif(not HAS_SMARTY, reason='SMARTy dependencies not installed')
+def check_dependency():
+    return pytest.mark.skipif(not HAS_SMARTY, reason='SMARTy dependencies not installed')
 
 
 @check_dependency()

--- a/sb_arch_opt/tests/algo/test_tpe.py
+++ b/sb_arch_opt/tests/algo/test_tpe.py
@@ -5,7 +5,8 @@ from sb_arch_opt.algo.tpe_interface import *
 from sb_arch_opt.problems.discrete import MDBranin
 from sb_arch_opt.problems.hidden_constraints import Alimo
 
-check_dependency = lambda: pytest.mark.skipif(not HAS_TPE, reason='TPE dependencies not installed')
+def check_dependency():
+    return pytest.mark.skipif(not HAS_TPE, reason='TPE dependencies not installed')
 
 
 @check_dependency()

--- a/sb_arch_opt/tests/algo/test_trieste.py
+++ b/sb_arch_opt/tests/algo/test_trieste.py
@@ -6,7 +6,8 @@ from sb_arch_opt.algo.trieste_interface import *
 from sb_arch_opt.problems.constrained import ArchCantileveredBeam
 from sb_arch_opt.algo.trieste_interface.algo import ArchOptBayesianOptimizer
 
-check_dependency = lambda: pytest.mark.skipif(not HAS_TRIESTE, reason='Trieste dependencies not installed')
+def check_dependency():
+    return pytest.mark.skipif(not HAS_TRIESTE, reason='Trieste dependencies not installed')
 
 
 @check_dependency()

--- a/sb_arch_opt/tests/problems/test_assignment.py
+++ b/sb_arch_opt/tests/problems/test_assignment.py
@@ -3,7 +3,8 @@ import numpy as np
 from sb_arch_opt.problems.assignment import *
 from sb_arch_opt.tests.problems.test_hierarchical import run_test_hierarchy
 
-check_dependency = lambda: pytest.mark.skipif(not HAS_ASSIGN_ENC, reason='assign_enc dependencies not installed')
+def check_dependency():
+    return pytest.mark.skipif(not HAS_ASSIGN_ENC, reason='assign_enc dependencies not installed')
 
 
 @check_dependency()

--- a/sb_arch_opt/tests/problems/test_rocket.py
+++ b/sb_arch_opt/tests/problems/test_rocket.py
@@ -3,7 +3,8 @@ from sb_arch_opt.problems.rocket import *
 from sb_arch_opt.problems.rocket_eval import *
 from sb_arch_opt.tests.problems.test_hierarchical import run_test_hierarchy
 
-check_dependency = lambda: pytest.mark.skipif(not HAS_ROCKET, reason='Rocket dependencies not installed')
+def check_dependency():
+    return pytest.mark.skipif(not HAS_ROCKET, reason='Rocket dependencies not installed')
 
 
 @check_dependency()

--- a/sb_arch_opt/tests/problems/test_turbofan_arch.py
+++ b/sb_arch_opt/tests/problems/test_turbofan_arch.py
@@ -9,7 +9,8 @@ from pymoo.optimize import minimize
 from pymoo.core.population import Population
 from pymoo.core.initialization import Initialization
 
-check_dependency = lambda: pytest.mark.skipif(not HAS_OPEN_TURB_ARCH, reason='Turbofan arch dependencies not installed')
+def check_dependency():
+    return pytest.mark.skipif(not HAS_OPEN_TURB_ARCH, reason='Turbofan arch dependencies not installed')
 
 
 @check_dependency()


### PR DESCRIPTION
- Fix the code for segomoe_test to run without errors when SEGOMOE is installed
- Modify the "try-except" clause in segomoe/algo to make it test only segomoe installation
- Add SMT and Numba to requirements
- Update SMT models for them to be used in SEGOMOE/moe with respect to SEGOMOE 6.1  last updates  
- Fixing tests for ArchSBO make a bug being discovered in SMT https://github.com/SMTorg/smt/pull/516 for more infos.